### PR TITLE
re-added sleep

### DIFF
--- a/ripper.py
+++ b/ripper.py
@@ -190,6 +190,9 @@ class Ripper:
                 successful_downloads.append(video_url)
             else:
                 failed_downloads.append(video_url)
+            sleep_time = random.uniform(self.sleep_min, self.sleep_max)
+            logger.info("Sleeping for: " + str(sleep_time) + " seconds")
+            sleep(sleep_time)
         logger.info("Processed all {} videos".format(self.video_count))
         logger.debug("Fallback counter: " + str(self.fallback_counter))
         logger.debug("YouTube-dl DownloadError counter: " + str(self.fallback_counter))


### PR DESCRIPTION
In the original version a random sleep would occur every time, not just on errors. Re-adding this since it might help with rate limiting. Does not seem to matter in my testing, but good for safety.